### PR TITLE
netlify 설정을 위한 파일을 수정했습니다.

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -5,3 +5,8 @@
 [context.production.environment]
   TOML_ENV_VAR = "From netlify.toml"
   REACT_APP_TOML_ENV_VAR = "From netlify.toml (REACT_APP_)"
+
+[[redirects]]
+  from = "/*"
+  to = "/"
+  status = 200


### PR DESCRIPTION
netlify 설정을 위한 파일을 수정했습니다.
기존 링크 
https://zippy-heliotrope-6168d0.netlify.app
로는 접속이 가능한데,
https://zippy-heliotrope-6168d0.netlify.app/login 처럼 추가로 redirection된 곳에 바로 접근 할 때
404 오류가 뜨고 있어 이를 해결하기 위함입니다.