### PR TITLE
Refresh ridirect solve

### DIFF
--- a/src/AdminComponent/AdminComponent.jsx
+++ b/src/AdminComponent/AdminComponent.jsx
@@ -11,7 +11,7 @@ function AdminComponent({ adminCheck }) {
   const navigate = useNavigate();
 
   useEffect(() => {
-    if (adminCheck == false) navigate('/login');
+    if (adminCheck != true) navigate('/login');
   }, [adminCheck]);
   return (
     <div>

--- a/src/AdminComponent/AdminComponent.jsx
+++ b/src/AdminComponent/AdminComponent.jsx
@@ -6,16 +6,34 @@ import AdminMainUsers from './AdminMainUsers/AdminMainUsers.jsx';
 import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 
-function AdminComponent({ adminCheck }) {
+function AdminComponent({ authToken, setAuthToken }) {
   const [renderComponentName, setRenderComponentName] = useState('Home');
   const navigate = useNavigate();
 
+  const isValidateAdminToken = (authToken) => {
+    /**
+     * autoToken이 Admin's Token인지 검사하는 API가 필요합니다.
+     * 현재는 모든 유저가 admin42 페이지에 접속이 가능한 상태입니다.
+     */
+    if (authToken != null) return true;
+  };
+
   useEffect(() => {
-    if (adminCheck != true) navigate('/login');
-  }, [adminCheck]);
+    if (authToken == null) {
+      const tmpToken = sessionStorage.getItem('authToken');
+      if (tmpToken != null) {
+        setAuthToken(tmpToken);
+      } else {
+        navigate('/login');
+      }
+    } else {
+      if (!isValidateAdminToken(authToken)) navigate('/login');
+    }
+  }, [authToken]);
+
   return (
     <div>
-      {adminCheck == false ? (
+      {authToken == false ? (
         <div>
           <h1>로그인 페이지로 돌아갑니다.</h1>
         </div>

--- a/src/AdminComponent/AdminMainUsers/AdminMainUsers.jsx
+++ b/src/AdminComponent/AdminMainUsers/AdminMainUsers.jsx
@@ -12,7 +12,7 @@ function AdminMainUsers() {
   const usersArguments = { pageSize: 15, pageNumber: 0, withAdmin: true, isNonLocked: true };
 
   const onClickReloadData = async () => {
-    const authToken = localStorage.getItem('authToken');
+    const authToken = sessionStorage.getItem('authToken');
     try {
       const response = await axios.get(
         `https://${process.env.REACT_APP_SERVER_HOST}/api/v1/admin/users/?pageSize=${usersArguments.pageSize}&pageNumber=${usersArguments.pageNumber}&withAdmin=${usersArguments.withAdmin}`,

--- a/src/App.js
+++ b/src/App.js
@@ -7,9 +7,7 @@ import MainComponent from './MainComponent/MainComponent.jsx';
 import AdminComponent from './AdminComponent/AdminComponent.jsx';
 
 function App() {
-  const [userInfo, setUserInfo] = useState(null);
-  const [adminCheck, setAdminCheck] = useState(false);
-  let isAuthorized = sessionStorage.getItem('isAuthorized');
+  const [authToken, setAuthToken] = useState(null);
 
   return (
     <React.StrictMode>
@@ -17,28 +15,19 @@ function App() {
         <Routes>
           <Route
             path="/login"
-            element={
-              <LoginComponent
-                setUserInfo={setUserInfo}
-                isAuthorized={isAuthorized}
-                setAdminCheck={setAdminCheck}
-              />
-            }
+            element={<LoginComponent authToken={authToken} setAuthToken={setAuthToken} />}
           />
           <Route path="/signin" element={<SignInComponent />} />
           <Route
             path="/"
-            element={<MainComponent isAuthorized={isAuthorized} userInfo={userInfo} />}
+            element={<MainComponent authToken={authToken} setAuthToken={setAuthToken} />}
           />
+          <Route path="/matmap" element={<MainComponent authToken={authToken} />} />
+          <Route path="/matstory" element={<MainComponent authToken={authToken} />} />
           <Route
-            path="/matmap"
-            element={<MainComponent isAuthorized={isAuthorized} userInfo={userInfo} />}
+            path="/admin42"
+            element={<AdminComponent authToken={authToken} setAuthToken={setAuthToken} />}
           />
-          <Route
-            path="/matstory"
-            element={<MainComponent isAuthorized={isAuthorized} userInfo={userInfo} />}
-          />
-          <Route path="/admin42" element={<AdminComponent adminCheck={adminCheck} />} />
         </Routes>
       </BrowserRouter>
     </React.StrictMode>

--- a/src/LoginComponent/LoginComponent.jsx
+++ b/src/LoginComponent/LoginComponent.jsx
@@ -4,7 +4,8 @@ import axios from 'axios';
 import BaseStyles from '../Base.module.css';
 import { useNavigate } from 'react-router-dom';
 
-function LoginComponent({ setUserInfo, setAdminCheck }) {
+// eslint-disable-next-line no-unused-vars
+function LoginComponent({ setAuthToken }) {
   const [account, setAccount] = useState({ id: '', password: '' });
   const navigate = useNavigate();
   const onChangeAccount = (e) => {
@@ -23,7 +24,8 @@ function LoginComponent({ setUserInfo, setAdminCheck }) {
           password: account.password,
         }
       );
-      localStorage.setItem('authToken', response.headers.authorization);
+      sessionStorage.setItem('authToken', response.headers.authorization);
+      //setAuthToken(response.headers.authorization);
       return response.data.role;
     } catch (error) {
       if (error.response) {
@@ -48,9 +50,7 @@ function LoginComponent({ setUserInfo, setAdminCheck }) {
     e.preventDefault();
     const role = await validateLogin();
     if (role == '[NORMAL]' || role == '[ADMIN]') {
-      setUserInfo(account);
-      sessionStorage.setItem('isAuthorized', true);
-      role == '[ADMIN]' ? (navigate('/admin42'), setAdminCheck(true)) : navigate('/');
+      role == '[ADMIN]' ? navigate('/admin42') : navigate('/');
       return { account };
     } else {
       alert('로그인 실패 !');

--- a/src/MainComponent/MainComponent.jsx
+++ b/src/MainComponent/MainComponent.jsx
@@ -5,23 +5,39 @@ import HeaderComponent from '../HeaderComponent/HeaderComponent.jsx';
 import MatMapComponent from '../MatMapComponent/MatMapComponent.jsx';
 import MatStoryComponent from '../MatStoryComponent/MatStoryComponent.jsx';
 
-function MainComponent({ isAuthorized, userInfo }) {
+function MainComponent({ authToken, setAuthToken }) {
   const [pageNum, setPageNum] = useState(0);
   const navigate = useNavigate();
+
+  const isValidateToken = (authToken) => {
+    /**
+     * autoToken이 Validate Token인지 검사하는 API가 필요합니다.
+     */
+    if (authToken != null) return true;
+  };
+
   useEffect(() => {
-    if (isAuthorized == null || userInfo == null) {
-      navigate('/login');
+    if (authToken == null) {
+      const tmpToken = sessionStorage.getItem('authToken');
+      if (tmpToken != null) {
+        setAuthToken(tmpToken);
+      } else {
+        navigate('/login');
+      }
+    } else {
+      if (!isValidateToken(authToken)) navigate('/login');
     }
-  }, [isAuthorized, userInfo]);
+  }, [authToken]);
+
   return (
     <div>
-      {isAuthorized == null || userInfo == null ? (
+      {authToken == null ? (
         <h1>로그인 페이지로 이동합니다.</h1>
       ) : (
         <div>
           <HeaderComponent setPageNum={setPageNum} />
-          {pageNum == 0 && <MatMapComponent userInfo={userInfo} />}
-          {pageNum == 1 && <MatStoryComponent userInfo={userInfo} />}
+          {pageNum == 0 && <MatMapComponent />}
+          {pageNum == 1 && <MatStoryComponent />}
         </div>
       )}
     </div>


### PR DESCRIPTION
새고로침 시에 로그인이 풀려 /login 페이지로 자동 redirection 되는 문제를 해결 하였습니다.

이를 위해 sessionStorage를 활용하여 Login 시 
sessionStorage.setItem('authToken', response.headers.authorization); 하였고,

Main과 Admin Component에서 
const tmpToken = sessionStorage.getItem('authToken');
하여 Token을 읽고 검증하였습니다.

현재 sessionStorage에 'authToken' 부분에 아무런 값이나 있으면 검증이 되는 상황이라,
일반 유저도 admin42 페이지에 접근 할 수 있으며 검증되지 않은 토큰 또한 정상적인 로그인으로 인식하고 있습니다.

이를 위해 읽어온 토큰 값이 유효한 토큰인지 서버에서 검증하여 Normal User 인지 Admin User 인지, 또는 불량 토큰인지 구별 할 수 있도록 하는 API가 필요합니다.

해당 API를 백엔드 쪽에 요청하였으니, API가 생기면 즉시 수정하도록 하겠습니다.

App.js에서 기존에 쓰던 변수들을 모두 삭제하여 모든 컴포넌트에 대한 수정이 있었던 만큼, 예원님이 진행하고 계시던 MatMapComponent에도 영향이 있을 수 있으니, merge가 되면 (로컬에서 작업 하시던 것을 백업을 먼저 하시고) main branch pull을 당겨서 이후 프로젝트를 마저 진행하시기 바랍니다.